### PR TITLE
Update AOCL dispatch to use amdlibm_vec

### DIFF
--- a/Eigen/src/Core/AOCL_Support.h
+++ b/Eigen/src/Core/AOCL_Support.h
@@ -57,8 +57,14 @@
    #define EIGEN_USE_BLAS     // Routes to libblis (e.g., bli_dgemm)
    #define EIGEN_USE_LAPACKE  // Routes to libflame (e.g., dsyev via LAPACKE)
  
-   // Include AOCL VML header
-   #include "amdlibm.h"
+  // Include AOCL VML header
+  #include "amdlibm.h"
+
+  // Enable experimental vector interfaces
+  #ifndef AMD_LIBM_VEC_EXPERIMENTAL
+    #define AMD_LIBM_VEC_EXPERIMENTAL
+  #endif
+  #include "amdlibm_vec.h"
  #endif
  
  // Handle strict LAPACKE usage

--- a/Eigen/src/Core/Assign_AOCL.h
+++ b/Eigen/src/Core/Assign_AOCL.h
@@ -51,24 +51,7 @@
  #include <cassert>
  #include "AOCL_Support.h"
  
- #ifdef __cplusplus
- extern "C" {
- #endif
- 
- // Declarations for AOCL MathLib vectorized functions (double precision only).
- // Input pointers are const since they are not modified.
- void vrda_exp(int length, const double *input, double *result);
- void vrda_sin(int length, const double *input, double *result);
- void vrda_cos(int length, const double *input, double *result);
- void vrda_sqrt(int length, const double *input, double *result);
- void vrda_log(int length, const double *input, double *result);
- void vrda_log10(int length, const double *input, double *result);
- void vrda_add(int len, const double *lhs, const double *rhs, double *dst);
- void vrda_pow(int length, const double *input1, const double *input2, double *result);
- 
- #ifdef __cplusplus
- }
- #endif
+#include "amdlibm_vec.h"
  
  // Define the SIMD width for AOCL MathLib (for AVX-512, typically 8 doubles).
  #ifndef AOCL_SIMD_WIDTH
@@ -157,7 +140,7 @@
              int simdBlocks = n / AOCL_SIMD_WIDTH;                               \
              int remainder = n % AOCL_SIMD_WIDTH;                                \
              if (simdBlocks > 0) {                                               \
-                 AOCLOP(simdBlocks * AOCL_SIMD_WIDTH, input, output);            \
+                 AOCLOP(simdBlocks * AOCL_SIMD_WIDTH, const_cast<double*>(input), output);            \
              }                                                                   \
              if (remainder > 0) {                                                \
                  int offset = simdBlocks * AOCL_SIMD_WIDTH;                      \
@@ -177,12 +160,12 @@
  //EIGEN_AOCL_VML_UNARY_CALL_FLOAT(log10)
  
  // Instantiate unary calls for double (AOCL vectorized).
- EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(exp, vrda_exp)
- EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(sin, vrda_sin)
- EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(cos, vrda_cos)
- EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(sqrt, vrda_sqrt)
- EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(log, vrda_log)
- EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(log10, vrda_log10)
+EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(exp, amd_vrda_exp)
+EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(sin, amd_vrda_sin)
+EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(cos, amd_vrda_cos)
+EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(sqrt, amd_vrda_sqrt)
+EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(log, amd_vrda_log)
+EIGEN_AOCL_VML_UNARY_CALL_DOUBLE(log10, amd_vrda_log10)
  
  // Binary operation dispatch for float (scalar fallback).
  #define EIGEN_AOCL_VML_BINARY_CALL_FLOAT(EIGENOP, STDFUNC)                      \
@@ -224,7 +207,7 @@
              const double* lhs = reinterpret_cast<const double*>(src.lhs().data()); \
              const double* rhs = reinterpret_cast<const double*>(src.rhs().data()); \
              double* output = reinterpret_cast<double*>(dst.data());             \
-             AOCLOP(n, lhs, rhs, output);                                        \
+             AOCLOP(n, const_cast<double*>(lhs), const_cast<double*>(rhs), output);                                        \
          }                                                                       \
      };
  
@@ -233,10 +216,11 @@
  //EIGEN_AOCL_VML_BINARY_CALL_FLOAT(pow, std::pow)
  
  // Instantiate binary calls for double (AOCL vectorized).
- EIGEN_AOCL_VML_BINARY_CALL_DOUBLE(sum, vrda_add)  // Using scalar_sum_op for addition
- EIGEN_AOCL_VML_BINARY_CALL_DOUBLE(pow, vrda_pow)
+EIGEN_AOCL_VML_BINARY_CALL_DOUBLE(sum, amd_vrda_add)  // Using scalar_sum_op for addition
+EIGEN_AOCL_VML_BINARY_CALL_DOUBLE(pow, amd_vrda_pow)
  
  } // namespace internal
  } // namespace Eigen
  
  #endif // EIGEN_ASSIGN_AOCL_H
+


### PR DESCRIPTION
## Summary
- use amdlibm_vec functions in AOCL dispatch
- include amdlibm_vec.h when AOCL is enabled

## Testing
- `cmake ..` *(fails: StandardMathLibrary not found)*
- `ctest --output-on-failure` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_685406f48c3c832890b32146760db1ed