### PR TITLE
Ensure AOCL benchmark links with required libraries

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -12,4 +12,6 @@ endif()
 
 if(AOCL_LIBRARIES)
   target_link_libraries(benchmark_aocl ${AOCL_LIBRARIES})
+  # Ensure pthread flags are used when linking
+  target_link_options(benchmark_aocl PRIVATE -pthread)
 endif()

--- a/cmake/FindAOCL.cmake
+++ b/cmake/FindAOCL.cmake
@@ -138,7 +138,8 @@ if(AOCL_LAPACK_LIB)
   list(APPEND AOCL_LIBRARIES ${AOCL_LAPACK_LIB})
 endif()
 if(AOCL_LIBRARIES)
-  list(APPEND AOCL_LIBRARIES lm pthread)
+  # Link against the standard math and pthread libraries as well as librt
+  list(APPEND AOCL_LIBRARIES m pthread rt)
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
## Summary
- update `FindAOCL.cmake` so AOCL libraries list includes `m`, `pthread`, and `rt`
- link `benchmark_aocl` with `-pthread`

## Testing
- `cmake .. -DEIGEN_BUILD_AOCL_BENCH=ON -DAOCL_ROOT=/tmp/aocl -DEIGEN_USE_AOCL_ALL=ON`
- `make benchmark_aocl`


------
https://chatgpt.com/codex/tasks/task_e_685a4914bfd88328bd1fc46b252613b1