### PR TITLE
Append AOCL flag to build script

### DIFF
--- a/scripts/build_aocl_example.sh
+++ b/scripts/build_aocl_example.sh
@@ -22,7 +22,8 @@ cmake .. -DEIGEN_BUILD_AOCL_BENCH=ON \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_INSTALL_PREFIX="${PWD}/install" \
-  -DINCLUDE_INSTALL_DIR="${PWD}/install/include" "$@"
+  -DINCLUDE_INSTALL_DIR="${PWD}/install/include" \
+  -DEIGEN_USE_AOCL_ALL=ON "$@"
 
 make -j$(nproc) benchmark_aocl
 


### PR DESCRIPTION
## Summary
- add `-DEIGEN_USE_AOCL_ALL=ON` option to build_aocl_example.sh
- keep user-supplied CMake options via `$@`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a48e189688328abec3af73d38725f