### PR TITLE
Add AOCL Makefile example

### DIFF
--- a/bench/Makefile.aocl
+++ b/bench/Makefile.aocl
@@ -1,0 +1,25 @@
+# Simplified Makefile to build the AOCL benchmark without CMake
+# Usage:
+#   make -f bench/Makefile.aocl
+
+EIGEN_INSTALL ?= build/install
+AOCL_ROOT ?= /opt/aocl
+
+CXX ?= clang++
+CXXFLAGS ?= -O3 -g -DEIGEN_USE_AOCL_ALL \
+	        -I$(EIGEN_INSTALL)/include -I$(AOCL_ROOT)/include -Wno-parentheses
+LDFLAGS ?= -L$(AOCL_ROOT)/lib -lamdlibm -lblis -lflame -lm -lpthread -lrt -pthread
+
+TARGET = build/eigen_aocl_example
+
+$(TARGET): bench/benchmark_aocl.cpp
+	mkdir -p build
+	$(CXX) $(CXXFLAGS) bench/benchmark_aocl.cpp \
+	$(LDFLAGS) -o $(TARGET)
+
+all: $(TARGET)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/doc/UsingAOCL.dox
+++ b/doc/UsingAOCL.dox
@@ -57,10 +57,15 @@ To enable AOCL optimisations you must:
    export LDFLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lblis -lflame -lm -lpthread -lrt -pthread"
    \endcode
 
-   Then compile the benchmark manually with:
-   \code
-   clang++ -O3 -DEIGEN_USE_AOCL_ALL -I${EIGEN_ROOT} -I${AOCL_ROOT}/include \
-           bench/benchmark_aocl.cpp ${LDFLAGS} -o eigen_aocl_example
+  Then compile the benchmark manually with:
+  \code
+  clang++ -O3 -DEIGEN_USE_AOCL_ALL -I${EIGEN_ROOT} -I${AOCL_ROOT}/include \
+          bench/benchmark_aocl.cpp ${LDFLAGS} -o eigen_aocl_example
+  \endcode
+   The file \c bench/Makefile.aocl replicates this command so you can build
+   the example simply with:
+   \code{.sh}
+   make -f bench/Makefile.aocl
    \endcode
 
 


### PR DESCRIPTION
## Summary
- add `bench/Makefile.aocl` for compiling the AOCL benchmark without CMake
- mention the Makefile in `doc/UsingAOCL.dox`

## Testing
- `./scripts/build_aocl_example.sh` *(fails: No rule to make target `benchmark_aocl`)*
- `make -f bench/Makefile.aocl` *(fails: missing AOCL headers)*

------
https://chatgpt.com/codex/tasks/task_e_685a4b9b54348328b2ce34864cbf505f