### PR TITLE
Document AOCL build/benchmark usage

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -3,7 +3,7 @@ project(EigenAOCLBench)
 add_executable(benchmark_aocl benchmark_aocl.cpp)
 
 target_compile_features(benchmark_aocl PRIVATE cxx_std_11)
-target_compile_options(benchmark_aocl PRIVATE -std=c++11)
+target_compile_options(benchmark_aocl PRIVATE -std=c++11 -Wno-deprecated-copy)
 
 if(EIGEN_STANDARD_LIBRARIES_TO_LINK_TO)
   target_link_libraries(benchmark_aocl ${EIGEN_STANDARD_LIBRARIES_TO_LINK_TO})

--- a/bench/Makefile.aocl
+++ b/bench/Makefile.aocl
@@ -7,7 +7,8 @@ AOCL_ROOT ?= /opt/aocl
 
 CXX ?= clang++
 CXXFLAGS ?= -O3 -g -DEIGEN_USE_AOCL_ALL \
-	        -I$(EIGEN_INSTALL)/include -I$(AOCL_ROOT)/include -Wno-parentheses
+                -I$(EIGEN_INSTALL)/include -I$(AOCL_ROOT)/include -Wno-parentheses \
+                -Wno-deprecated-copy
 LDFLAGS ?= -L$(AOCL_ROOT)/lib -lamdlibm -lblis -lflame -lm -lpthread -lrt -pthread
 
 TARGET = build/eigen_aocl_example

--- a/bench/benchmark_aocl.cpp
+++ b/bench/benchmark_aocl.cpp
@@ -29,92 +29,92 @@ void benchmarkVectorMath(int size) {
     cout << "\n--- Vector Math Benchmark (size = " << size << ") ---" << endl;
 
     auto start = high_resolution_clock::now();
-    result = v.array().exp();
+    result = v.array().exp().eval();
     auto end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "exp() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().sin();
+    result = v.array().sin().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "sin() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().cos();
+    result = v.array().cos().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "cos() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().sqrt();
+    result = v.array().sqrt().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "sqrt() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().log();
+    result = v.array().log().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "log() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().log10();
+    result = v.array().log10().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "log10() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().asin();
+    result = v.array().asin().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "asin() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().sinh();
+    result = v.array().sinh().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "sinh() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().acos();
+    result = v.array().acos().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "acos() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().cosh();
+    result = v.array().cosh().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "cosh() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().tan();
+    result = v.array().tan().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "tan() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().atan();
+    result = v.array().atan().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "atan() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().tanh();
+    result = v.array().tanh().eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "tanh() time: " << elapsed_ms << " ms" << endl;
 
     VectorXd v2 = VectorXd::Random(size);
     start = high_resolution_clock::now();
-    result = v.array() + v2.array();
+    result = (v.array() + v2.array()).eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "add() time: " << elapsed_ms << " ms" << endl;
 
     start = high_resolution_clock::now();
-    result = v.array().pow(2.0);
+    result = v.array().pow(2.0).eval();
     end = high_resolution_clock::now();
     elapsed_ms = duration_cast<milliseconds>(end - start).count();
     cout << "pow() time: " << elapsed_ms << " ms" << endl;

--- a/doc/UsingAOCL.dox
+++ b/doc/UsingAOCL.dox
@@ -57,18 +57,24 @@ To enable AOCL optimisations you must:
    export LDFLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lblis -lflame -lm -lpthread -lrt -pthread"
    \endcode
 
-  Then compile the benchmark manually with:
-  \code
-  clang++ -O3 -DEIGEN_USE_AOCL_ALL -I${EIGEN_ROOT} -I${AOCL_ROOT}/include \
+\subsection TopicUsingAOCL_BuildExamples Build command examples
+Typical ways to build Eigen with AOCL include:
+ - **Manual compilation** using \c clang++
+   \code
+   clang++ -O3 -DEIGEN_USE_AOCL_ALL -I${EIGEN_ROOT} -I${AOCL_ROOT}/include \
           bench/benchmark_aocl.cpp ${LDFLAGS} -o eigen_aocl_example
-  \endcode
-   The file \c bench/Makefile.aocl replicates this command so you can build
-   the example simply with:
+   \endcode
+ - **Using the provided Makefile**
    \code{.sh}
    make -f bench/Makefile.aocl
    \endcode
+ - **Via CMake** (configure and build in a separate directory)
+   \code
+   cmake .. -DEIGEN_USE_AOCL_ALL=ON -DAOCL_ROOT=/path/to/aocl
+   make
+   \endcode
 
-
+\subsection TopicUsingAOCL_Integration Integration details
 When \c EIGEN_USE_AOCL_ALL is defined, Eigen automatically defines the
 following macros:
  - \c EIGEN_USE_AOCL_VML  (for vector math dispatch)
@@ -100,6 +106,14 @@ make benchmark_aocl
 \endcode
 the necessary LDFLAGS are applied automatically.
 
+\section TopicUsingAOCL_Benchmark Benchmark and components
+The optional benchmark \c bench/benchmark_aocl.cpp exercises AOCL's vector
+math, BLAS (via \c libblis) and LAPACK (via \c libflame) implementations.
+It is built when the CMake option \c EIGEN_BUILD_AOCL_BENCH is enabled or via
+the provided \c bench/Makefile.aocl. The resulting executable links against
+\c libamdlibm, \c libblis and \c libflame in addition to the standard math
+library.
+
 \section TopicUsingAOCL_Dispatch Dispatch layer
 
 The header \c Eigen/src/Core/Assign_AOCL.h implements specialisations of
@@ -109,6 +123,34 @@ routines like \c amd_vrda_exp when the expression size exceeds
 \c EIGEN_AOCL_VML_THRESHOLD (128 by default). Operations on smaller
 vectors or unsupported scalar types fall back to Eigen's built-in
 implementation.
+
+\subsection TopicUsingAOCL_VMLFunctions AOCL vector math functions
+When AOCL is enabled, Eigen dispatches various coefficient-wise math
+operations to AMD's optimized vector routines. The following table
+summarises the main mappings:
+
+<table class="manual">
+<tr><th>Eigen expression</th><th>AOCL routine</th></tr>
+<tr><td>\c v.array().exp()</td><td>\c amd_vrda_exp</td></tr>
+<tr class="alt"><td>\c v.array().sin()</td><td>\c amd_vrda_sin</td></tr>
+<tr><td>\c v.array().cos()</td><td>\c amd_vrda_cos</td></tr>
+<tr class="alt"><td>\c v.array().sqrt()</td><td>\c amd_vrda_sqrt</td></tr>
+<tr><td>\c v.array().log()</td><td>\c amd_vrda_log</td></tr>
+<tr class="alt"><td>\c v.array().log10()</td><td>\c amd_vrda_log10</td></tr>
+<tr><td>\c v.array().asin()</td><td>\c amd_vrda_asin</td></tr>
+<tr class="alt"><td>\c v.array().sinh()</td><td>\c amd_vrda_sinh</td></tr>
+<tr><td>\c v.array().acos()</td><td>\c amd_vrda_acos</td></tr>
+<tr class="alt"><td>\c v.array().cosh()</td><td>\c amd_vrda_cosh</td></tr>
+<tr><td>\c v.array().tan()</td><td>\c amd_vrda_tan</td></tr>
+<tr class="alt"><td>\c v.array().atan()</td><td>\c amd_vrda_atan</td></tr>
+<tr><td>\c v.array().tanh()</td><td>\c amd_vrda_tanh</td></tr>
+<tr class="alt"><td>\c v.array().log2()</td><td>\c amd_vrda_log2</td></tr>
+<tr><td>\c (a.array() + b.array())</td><td>\c amd_vrda_add</td></tr>
+<tr class="alt"><td>\c pow(a.array(), b)</td><td>\c amd_vrda_pow</td></tr>
+</table>
+
+Operations not provided by AOCL automatically revert to Eigen's own
+implementations.
 
 \section TopicUsingAOCL_Notes Notes
  - AOCL is optional. If the libraries are not found or the macro is not


### PR DESCRIPTION
## Summary
- expand documentation for AOCL build options and integration
- list AOCL vector math functions Eigen dispatches to
- silence deprecated copy warnings when building benchmark
- fix missing newline in CMakeLists for the benchmark

## Testing
- `ctest -j1` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa731b91883289789b48169203fc8